### PR TITLE
Treat spaces as part of the resource names

### DIFF
--- a/lib/jsonapi/include_directive/parser.rb
+++ b/lib/jsonapi/include_directive/parser.rb
@@ -24,7 +24,6 @@ module JSONAPI
       # @api private
       def parse_string(include_string)
         include_string.split(',')
-          .map(&:strip)
           .each_with_object({}) do |path, hash|
             deep_merge!(hash, parse_path_string(path))
         end

--- a/spec/include_directive/parser_spec.rb
+++ b/spec/include_directive/parser_spec.rb
@@ -16,13 +16,26 @@ describe JSONAPI::IncludeDirective::Parser, '.parse_include_args' do
     expect(hash).to eq expected
   end
 
-  it 'handles strings with spaces' do
-    str = 'friends, comments.author, posts.author, posts.comments.author'
+  it 'handles strings' do
+    str = 'friends,comments.author,posts.author,posts.comments.author'
     hash = JSONAPI::IncludeDirective::Parser.parse_include_args(str)
     expected = {
       friends: {},
       comments: { author: {} },
       posts: { author: {}, comments: { author: {} } }
+    }
+
+    expect(hash).to eq expected
+  end
+
+  it 'treats spaces as part of the resource name' do
+    str = 'friends, comments.author , posts.author,posts. comments.author'
+    hash = JSONAPI::IncludeDirective::Parser.parse_include_args(str)
+    expected = {
+      friends: {},
+      :' comments' => { :'author ' => {} },
+      :' posts' => { author: {} },
+      :'posts' => { :' comments' => { author: {} } }
     }
 
     expect(hash).to eq expected


### PR DESCRIPTION
Logic being they are not allowed as the first or last character of a
member name. By passing them through the parser an error can be raised
when the includedirectives are validated. If the parser strips them out
we lose the ability to raise an error.