### PR TITLE
[WIP] Link resource identifiers to corresponding resources.

### DIFF
--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -23,7 +23,15 @@ module JSONAPI
     end
 
     def collection?
-      @data.is_a?(Array)
+      data.is_a?(Array)
+    end
+
+    def link_resources(index)
+      if collection?
+        data.each { |ri| ri.link_resource(index) }
+      elsif !data.nil?
+        data.link_resource(index)
+      end
     end
 
     private

--- a/lib/jsonapi/resource_identifier.rb
+++ b/lib/jsonapi/resource_identifier.rb
@@ -1,7 +1,7 @@
 module JSONAPI
   # c.f. http://jsonapi.org/format/#document-resource-identifier-objects
   class ResourceIdentifier
-    attr_reader :id, :type
+    attr_reader :id, :type, :resource
 
     def initialize(resource_identifier_hash, options = {})
       @hash = resource_identifier_hash
@@ -14,6 +14,10 @@ module JSONAPI
 
     def to_hash
       @hash
+    end
+
+    def link_resource(index)
+      @resource = index[[type, id]]
     end
 
     private


### PR DESCRIPTION
Note: Not sure this should/will get merged.

By specifying the option `link_relationships: true` to the parser, one can access linked resources as follows:
```ruby
resource.relationships[:author].resource
resource.relationships[:comments][3].resource
```