### PR TITLE
Do not rely on JSON gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     jsonapi (0.1.1.beta2)
-      json (~> 1.8)
 
 GEM
   remote: https://rubygems.org/
@@ -40,4 +39,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/jsonapi_parser.gemspec
+++ b/jsonapi_parser.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'json', '~>1.8'
-
   spec.add_development_dependency 'rake', '>=0.9'
   spec.add_development_dependency 'rspec', '~>3.4'
   spec.add_development_dependency 'simplecov'

--- a/lib/jsonapi/parse.rb
+++ b/lib/jsonapi/parse.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module JSONAPI
   module_function
 


### PR DESCRIPTION
It makes it possible to use JSONAPI gem inside RubyMotion projects without having a lot of warnings on every run.