### PR TITLE
Remove json dependency. JSONAPI.parse now only accepts a hash.

### DIFF
--- a/parser/jsonapi-parser.gemspec
+++ b/parser/jsonapi-parser.gemspec
@@ -12,6 +12,4 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['LICENSE', 'README.md', 'lib/**/*']
   spec.require_path  = 'lib'
-
-  spec.add_dependency 'json', '~>1.8'
 end

--- a/parser/lib/jsonapi/parser.rb
+++ b/parser/lib/jsonapi/parser.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 require 'jsonapi/parser/attributes'
 require 'jsonapi/parser/document'
 require 'jsonapi/parser/error'

--- a/parser/lib/jsonapi/parser.rb
+++ b/parser/lib/jsonapi/parser.rb
@@ -24,8 +24,6 @@ module JSONAPI
   # @return [JSONAPI::Parser::Document]
   def parse(document, options = {})
     raise Parser::InvalidDocument, 'document must be a hash' unless document.is_a?(Hash)
-    hash = document.is_a?(Hash) ? document : JSON.parse(document)
-
-    Parser::Document.new(hash, options)
+    Parser::Document.new(document, options)
   end
 end

--- a/parser/lib/jsonapi/parser.rb
+++ b/parser/lib/jsonapi/parser.rb
@@ -17,7 +17,7 @@ module JSONAPI
 
   # Parse a JSON API document.
   #
-  # @param document [Hash, String] the JSON API document.
+  # @param document [Hash] the JSON API document.
   # @param options [Hash] options
   #   @option options [Boolean] :id_optional (false) Whether the resource
   #     objects in the primary data must have an id.

--- a/parser/lib/jsonapi/parser.rb
+++ b/parser/lib/jsonapi/parser.rb
@@ -23,7 +23,7 @@ module JSONAPI
   #     objects in the primary data must have an id.
   # @return [JSONAPI::Parser::Document]
   def parse(document, options = {})
-    raise Parser::InvalidDocument, 'document cannot be nil' if document.nil?
+    raise Parser::InvalidDocument, 'document must be a hash' unless document.is_a?(Hash)
     hash = document.is_a?(Hash) ? document : JSON.parse(document)
 
     Parser::Document.new(hash, options)

--- a/parser/lib/jsonapi/parser.rb
+++ b/parser/lib/jsonapi/parser.rb
@@ -23,6 +23,7 @@ module JSONAPI
   #     objects in the primary data must have an id.
   # @return [JSONAPI::Parser::Document]
   def parse(document, options = {})
+    raise Parser::InvalidDocument, 'document cannot be nil' if document.nil?
     hash = document.is_a?(Hash) ? document : JSON.parse(document)
 
     Parser::Document.new(hash, options)

--- a/parser/spec/parser_spec.rb
+++ b/parser/spec/parser_spec.rb
@@ -110,4 +110,10 @@ describe JSONAPI::Parser, '#parse' do
         .to raise_error JSONAPI::Parser::InvalidDocument
     end
   end
+
+  it 'raises InvalidDocument on nil input' do
+    expect {
+      JSONAPI.parse(nil)
+    }.to raise_error JSONAPI::Parser::InvalidDocument
+  end
 end


### PR DESCRIPTION
Superseds #40, fixes #33, #35.