### PR TITLE
Renderer

### DIFF
--- a/jsonapi_parser.gemspec
+++ b/jsonapi_parser.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'json', '~>1.8'
+  spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'rake', '>=0.9'
   spec.add_development_dependency 'rspec', '~>3.4'

--- a/lib/jsonapi.rb
+++ b/lib/jsonapi.rb
@@ -12,6 +12,7 @@ require 'jsonapi/relationships'
 require 'jsonapi/resource'
 require 'jsonapi/resource_identifier'
 
+require 'jsonapi/renderer'
 require 'jsonapi/parse'
 
 module JSONAPI

--- a/lib/jsonapi/include_directive.rb
+++ b/lib/jsonapi/include_directive.rb
@@ -27,6 +27,11 @@ module JSONAPI
         (@options[:allow_wildcard] && (@hash.key?(:*) || @hash.key?(:**)))
     end
 
+    # @return [Array<Symbol>]
+    def keys
+      @hash.keys
+    end
+
     # @param key [Symbol, String]
     # @return [IncludeDirective, nil]
     def [](key)

--- a/lib/jsonapi/renderer.rb
+++ b/lib/jsonapi/renderer.rb
@@ -6,8 +6,7 @@ module JSONAPI
       @meta = options[:meta] || nil
       @links = options[:links] || {}
       @fields = options[:fields] || {}
-      # NOTE(beauby): Room for some nifty defaults on those.
-      @jsonapi = nil
+      @jsonapi = nil # NOTE(beauby): Room for some nifty defaults on those.
       @include = JSONAPI::IncludeDirective.new(options[:include] || {})
     end
 
@@ -90,23 +89,10 @@ module JSONAPI
             rel_hash[:meta] = rel.meta unless rel.meta.nil?
           end
           if include_dir.key?(key) && !rel_hash.key?(:data)
-            data =
-              if rel.linkage_data.nil?
-                Array(rel.data).map do |rel_res|
-                  type, id = resource_identifier(rel_res)
-                  { type: type, id: id }
-                end
-              else
-                Array(rel.linkage_data)
-              end
-            rel_hash[:data] = rel.data.respond_to?(:each) ? data : data[0]
+            rel_hash[:data] = rel.linkage_data
           end
         end
       end
-    end
-
-    def field_whitelist(type)
-      @fields[type.to_sym]
     end
 
     def filter_fields(type, hash)

--- a/lib/jsonapi/renderer.rb
+++ b/lib/jsonapi/renderer.rb
@@ -58,7 +58,7 @@ module JSONAPI
 
     def process_resource(res, prefix, include_dir, is_primary)
       ri = [res.jsonapi_type, res.jsonapi_id]
-      hash = res.as_jsonapi(fileds: @fields[res.jsonapi_type],
+      hash = res.as_jsonapi(fields: @fields[res.jsonapi_type],
                             include: include_dir.keys)
       if @hashes.key?(ri)
         merge_resources!(@hashes[ri], hash)

--- a/lib/jsonapi/renderer.rb
+++ b/lib/jsonapi/renderer.rb
@@ -35,14 +35,14 @@ module JSONAPI
       @primary = []
       @included = []
       @hashes = {}
-      @processed = Set.new  # NOTE(beauby): Set of [type, id, prefix].
+      @processed = Set.new # NOTE(beauby): Set of [type, id, prefix].
       @queue = []
 
       Array(@resources).each do |res|
         process_resource(res, '', @include, true)
         @processed.add([res.jsonapi_type, res.jsonapi_id, ''])
       end
-      until @queue.empty? do
+      until @queue.empty?
         res, prefix, include_dir = @queue.pop
         process_resource(res, prefix, include_dir, false)
       end
@@ -65,10 +65,10 @@ module JSONAPI
       else
         (is_primary ? @primary : @included) << (@hashes[ri] = hash)
       end
-      process_relationships(hash, res, prefix, include_dir)
+      process_relationships(res, prefix, include_dir)
     end
 
-    def process_relationships(hash, res, prefix, include_dir)
+    def process_relationships(res, prefix, include_dir)
       res.jsonapi_related(include_dir.keys).each do |key, data|
         Array(data).each do |child_res|
           child_prefix = "#{prefix}.#{key}"

--- a/lib/jsonapi/renderer.rb
+++ b/lib/jsonapi/renderer.rb
@@ -1,0 +1,138 @@
+module JSONAPI
+  class Renderer
+    def initialize(resources, options = {})
+      @resources = resources
+      @errors = options[:errors] || false
+      @meta = options[:meta] || nil
+      @links = options[:links] || {}
+      @fields = options[:fields] || {}
+      # NOTE(beauby): Room for some nifty defaults on those.
+      @jsonapi = nil
+      @include = JSONAPI::IncludeDirective.new(options[:include] || {})
+    end
+
+    def as_json
+      return @json unless @json.nil?
+
+      process_resources
+      @json = {}
+
+      if @errors
+        @json[:errors] = @resources.map(&:error_hash)
+      else
+        @json[:data] = @resources.respond_to?(:each) ? @primary : @primary[0]
+        @json[:included] = @included if @included.any?
+      end
+      @json[:links] = @links if @links.any?
+      @json[:meta] = @meta unless @meta.nil?
+      @json[:jsonapi] = @jsonapi unless @jsonapi.nil?
+
+      @json
+    end
+
+    private
+
+    def process_resources
+      @primary = []
+      @included = []
+      @hashes = {}
+      @processed = Set.new  # NOTE(beauby): Set of [type, id, prefix].
+      @queue = []
+
+      Array(@resources).each do |res|
+        process_resource(res, "", @include, true)
+        @processed.add([res.type, res.id, ""])
+      end
+      until @queue.empty? do
+        res, prefix, include_dir = @queue.pop
+        process_resource(res, prefix, include_dir, false)
+      end
+    end
+
+    def resource_identifier(res)
+      [res.type, res.id]
+    end
+
+    def process_resource(res, prefix, include_dir, is_primary)
+      hash = (@hashes[resource_identifier(res)] ||= {})
+      if hash.empty?
+        hash[:id] = res.id
+        hash[:type] = res.type
+        filtered_attributes = filter_fields(res.type, res.attributes)
+        hash[:attributes] = filtered_attributes if filtered_attributes.any?
+        hash[:links] = res.links if res.links.any?
+        hash[:meta] = res.meta unless res.meta.nil?
+        if is_primary
+          @primary << hash
+        else
+          @included << hash
+        end
+      end
+      process_relationships(hash, res, prefix, include_dir)
+    end
+
+    def process_relationships(hash, res, prefix, include_dir)
+      whitelist = @fields[res.type.to_sym]
+      res.relationships.each do |key, rel|
+        if include_dir.key?(key) # NOTE(beauby): || always_include_linkage
+          Array(rel.data).each do |child_res|
+            child_prefix = prefix + key.to_s
+            next unless @processed.add?([child_res.type, child_res.id, child_prefix])
+            @queue << [child_res, child_prefix, include_dir[key]]
+          end
+        end
+
+        if whitelist.nil? || whitelist.include?(key)
+          hash[:relationships] ||= {}
+          rel_hash = (hash[:relationships][key] ||= {})
+          if rel_hash.empty?
+            rel_hash[:links] = rel.links if rel.links.any?
+            rel_hash[:meta] = rel.meta unless rel.meta.nil?
+          end
+          if include_dir.key?(key) && !rel_hash.key?(:data)
+            data =
+              if rel.linkage_data.nil?
+                Array(rel.data).map do |rel_res|
+                  type, id = resource_identifier(rel_res)
+                  { type: type, id: id }
+                end
+              else
+                Array(rel.linkage_data)
+              end
+            rel_hash[:data] = rel.data.respond_to?(:each) ? data : data[0]
+          end
+        end
+      end
+    end
+
+    def field_whitelist(type)
+      @fields[type.to_sym]
+    end
+
+    def filter_fields(type, hash)
+      whitelist = @fields[type.to_sym]
+      return hash if whitelist.nil?
+      hash.select { |k, _| whitelist.include?(k) }
+    end
+
+    def error_hash(error)
+      hash = {}
+      hash[:id] = error.id unless error.id.nil?
+      hash[:links] = error.links unless error.links.nil?
+      hash[:status] = error.status unless error.status.nil?
+      hash[:code] = error.code unless error.code.nil?
+      hash[:title] = error.title unless error.title.nil?
+      hash[:detail] = error.detail unless error.detail.nil?
+      hash[:source] = error.source unless error.source.nil?
+      hash[:meta] = error.meta unless error.meta.nil?
+
+      hash
+    end
+  end
+
+  module_function
+
+  def render(resources, options = {})
+    Renderer.new(resources, options).as_json
+  end
+end

--- a/lib/jsonapi/serializable_error.rb
+++ b/lib/jsonapi/serializable_error.rb
@@ -1,0 +1,177 @@
+require 'jsonapi/serializable_link'
+
+# TEMP
+require 'active_support/core_ext/class/attribute'
+
+module JSONAPI
+  class SerializableErrorSource
+    def initialize(params = {})
+      params.each do |name, value|
+        instance_variable_set("@#{name}", value)
+      end
+    end
+
+    def as_json
+      hash = {}
+      hash[:pointer] = pointer unless pointer.nil?
+      hash[:parameter] = parameter unless parameter.nil?
+
+      hash
+    end
+
+    private
+
+    def pointer(value = nil, &block)
+      if value.nil? && block.nil?
+        @_pointer
+      else
+        @_pointer = (value || instance_eval(&block))
+      end
+    end
+
+    def parameter(value = nil, &block)
+      if value.nil? && block.nil?
+        @_parameter
+      else
+        @_parameter = (value || instance_eval(&block))
+      end
+    end
+  end
+
+  class SerializableError
+    class_attribute :id
+    class_attribute :id_block
+    class_attribute :link_blocks
+    class_attribute :status
+    class_attribute :status_block
+    class_attribute :code
+    class_attribute :code_block
+    class_attribute :title
+    class_attribute :title_block
+    class_attribute :detail
+    class_attribute :detail_block
+    class_attribute :source
+    class_attribute :source_block
+    class_attribute :meta
+    class_attribute :meta_block
+
+    self.link_blocks = {}
+
+    def self.id(value = nil, &block)
+      self.id = value
+      self.id_block = block
+    end
+
+    def self.link(name, &block)
+      self.link_blocks[name] = block
+    end
+
+    def self.status(value = nil, &block)
+      self.status = value
+      self.status_block = block
+    end
+
+    def self.code(value = nil, &block)
+      self.code = value
+      self.code_block = block
+    end
+
+    def self.title(value = nil, &block)
+      self.title = value
+      self.title_block = block
+    end
+
+    def self.detail(value = nil, &block)
+      self.detail = value
+      self.detail_block = block
+    end
+
+    def self.source(value = nil, &block)
+      self.source = value
+      self.source_block = block
+    end
+
+    def self.meta(value = nil, &block)
+      self.meta = value
+      self.meta_block = block
+    end
+
+    def initialize(params = {})
+      @_param_hash = params
+      params.each do |name, value|
+        instance_variable_set("@#{name}", value)
+      end
+    end
+
+    # TODO: those are optional fields
+    def id
+      @_id ||=
+        if self.class.id_block
+          instance_eval(self.class.id_block)
+        elsif 
+          self.class.id
+        end
+    end
+
+    def links
+      @_links ||= self.class.link_blocks
+                .each_with_object({}) do |(name, block), hash|
+        hash[name] = JSONAPI::SerializableLink.new(@_param_hash, block).to_hash
+      end
+    end
+
+    def status
+      @_status ||=
+        if self.class.status_block
+          instance_eval(self.class.status_block)
+        else
+          self.class.status
+        end
+    end
+
+    def code
+      @_code ||=
+        if self.class.code_block
+          instance_eval(self.class.code_block)
+        else
+          self.class.code
+        end
+    end
+
+    def title
+      @_title ||=
+        if self.class.title_block
+          instance_eval(self.class.title_block)
+        else
+          self.class.title
+        end
+    end
+
+    def detail
+      @_detail ||=
+        if self.class.detail_block
+          instance_eval(self.class.detail_block)
+        else
+          self.class.detail
+        end
+    end
+
+    def source
+      @_source ||=
+        if self.class.source_block
+          instance_eval(self.class.source_block)
+        else
+          self.class.source
+        end
+    end
+
+    def meta
+      @_meta =
+        if self.class.meta_block
+          instance_eval(self.class.meta_block)
+        else
+          self.class.meta
+        end
+    end
+  end
+end

--- a/lib/jsonapi/serializable_error.rb
+++ b/lib/jsonapi/serializable_error.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/class/attribute'
 require 'jsonapi/serializable_link'
 
 module JSONAPI
@@ -24,15 +23,10 @@ module JSONAPI
   end
 
   class SerializableError
-    class_attribute :id, :id_block, :status, :status_block, :code, :code_block,
+    class << self
+      attr_accessor :id, :id_block, :status, :status_block, :code, :code_block,
                     :title, :title_block, :detail, :detail_block, :meta,
                     :meta_block, :source_block, :link_blocks
-    self.link_blocks = {}
-
-    class << self
-      def inherited(subclass)
-        subclass.link_blocks = {}
-      end
 
       [:id, :status, :code, :title, :detail, :meta].each do |key|
         define_method(key) do |*args, &block|
@@ -48,6 +42,13 @@ module JSONAPI
       def source(&block)
         self.source_block = block
       end
+    end
+
+    self.link_blocks = {}
+
+    def self.inherited(klass)
+      super
+      klass.link_blocks = self.class.link_blocks.dup
     end
 
     def initialize(params = {})

--- a/lib/jsonapi/serializable_error.rb
+++ b/lib/jsonapi/serializable_error.rb
@@ -8,9 +8,7 @@ module JSONAPI
     end
 
     def initialize(params = {})
-      params.each do |name, value|
-        instance_variable_set("@#{name}", value)
-      end
+      params.each { |k, v| instance_variable_set("@#{k}", v) }
       @_data = {}
     end
 

--- a/lib/jsonapi/serializable_error.rb
+++ b/lib/jsonapi/serializable_error.rb
@@ -1,6 +1,5 @@
-require 'jsonapi/serializable_link'
-
 require 'active_support/core_ext/class/attribute'
+require 'jsonapi/serializable_link'
 
 module JSONAPI
   class SerializableErrorSource
@@ -32,7 +31,7 @@ module JSONAPI
                     :meta_block, :source_block, :link_blocks
     self.link_blocks = {}
 
-    class<< self
+    class << self
       def inherited(subclass)
         subclass.link_blocks = {}
       end
@@ -55,9 +54,7 @@ module JSONAPI
 
     def initialize(params = {})
       @_param_hash = params
-      params.each do |name, value|
-        instance_variable_set("@#{name}", value)
-      end
+      params.each { |k, v| instance_variable_set("@#{k}", v) }
     end
 
     def as_jsonapi

--- a/lib/jsonapi/serializable_error.rb
+++ b/lib/jsonapi/serializable_error.rb
@@ -38,13 +38,13 @@ module JSONAPI
 
       [:id, :status, :code, :title, :detail, :meta].each do |key|
         define_method(key) do |*args, &block|
-          self.send("@#{key}=", args[0])
-          self.send("@#{key}_block=", block)
+          send("@#{key}=", args[0])
+          send("@#{key}_block=", block)
         end
       end
 
       def link(name, &block)
-        self.link_blocks[name] = block
+        link_blocks[name] = block
       end
 
       def source(&block)
@@ -75,8 +75,9 @@ module JSONAPI
     end
 
     def source
-      @_source ||= JSONAPI::SerializableErrorSource.as_jsonapi(
-        @_param_hash, self.class.source_block)
+      @_source ||=
+        JSONAPI::SerializableErrorSource.as_jsonapi(@_param_hash,
+                                                    self.class.source_block)
     end
 
     [:id, :status, :code, :title, :detail, :meta].each do |key|

--- a/lib/jsonapi/serializable_link.rb
+++ b/lib/jsonapi/serializable_link.rb
@@ -1,5 +1,9 @@
 module JSONAPI
   class SerializableLink
+    def self.as_jsonapi(param_hash = {}, &block)
+      self.new(param_hash, &block).as_jsonapi
+    end
+
     def initialize(param_hash = {}, &block)
       param_hash.each do |k, v|
         instance_variable_set("@#{k}", v)
@@ -8,7 +12,7 @@ module JSONAPI
       @_href ||= str_value
     end
 
-    def to_hash
+    def as_jsonapi
       @_hash ||=
         if @_meta.nil?
           @_href

--- a/lib/jsonapi/serializable_link.rb
+++ b/lib/jsonapi/serializable_link.rb
@@ -1,7 +1,7 @@
 module JSONAPI
   class SerializableLink
     def self.as_jsonapi(param_hash = {}, &block)
-      self.new(param_hash, &block).as_jsonapi
+      new(param_hash, &block).as_jsonapi
     end
 
     def initialize(param_hash = {}, &block)

--- a/lib/jsonapi/serializable_link.rb
+++ b/lib/jsonapi/serializable_link.rb
@@ -1,0 +1,30 @@
+module JSONAPI
+  class SerializableLink
+    def initialize(param_hash = {}, &block)
+      param_hash.each do |k, v|
+        instance_variable_set("@#{k}", v)
+      end
+      str_value = instance_eval(&block)
+      @_href ||= str_value
+    end
+
+    def to_hash
+      @_hash ||=
+        if @_meta.nil?
+          @_href
+        else
+          { href: @_href, meta: @_meta }
+        end
+    end
+
+    private
+
+    def href(value = nil, &block)
+      @_href = block.nil? ? value : instance_eval(&block)
+    end
+
+    def meta(value = nil, &block)
+      @_meta = block.nil? ? value : instance_eval(&block)
+    end
+  end
+end

--- a/lib/jsonapi/serializable_relationship.rb
+++ b/lib/jsonapi/serializable_relationship.rb
@@ -1,0 +1,48 @@
+require 'jsonapi/serializable_link'
+
+module JSONAPI
+  class SerializableRelationship
+    def initialize(param_hash = {}, &block)
+      @_param_hash = param_hash
+      @_param_hash.each do |k, v|
+        instance_variable_set("@#{k}", v)
+      end
+      @_links = {}
+      instance_eval(&block)
+    end
+
+    def data(&block)
+      if block.nil?
+        @_data ||= @_data_block.call
+      else
+        @_data_block = block
+      end
+    end
+
+    def linkage_data(&block)
+      if block.nil?
+        @_linkage_data ||= (@_linkage_data_block && @_linkage_data_block.call)
+      else
+        @_linkage_data_block = block
+      end
+    end
+
+    def meta(value = nil, &block)
+      if value.nil? && block.nil?
+        @_meta
+      else
+        @_meta = (value || block.call)
+      end
+    end
+
+    def links
+      @_links
+    end
+
+    private
+
+    def link(name, &block)
+      @_links[name] = JSONAPI::SerializableLink.new(@_param_hash, &block).to_hash
+    end
+  end
+end

--- a/lib/jsonapi/serializable_relationship.rb
+++ b/lib/jsonapi/serializable_relationship.rb
@@ -4,9 +4,7 @@ module JSONAPI
   class SerializableRelationship
     def initialize(param_hash = {}, &block)
       @_param_hash = param_hash
-      @_param_hash.each do |k, v|
-        instance_variable_set("@#{k}", v)
-      end
+      @_param_hash.each { |k, v| instance_variable_set("@#{k}", v) }
       @_links = {}
       instance_eval(&block)
     end
@@ -19,39 +17,40 @@ module JSONAPI
       end
     end
 
-    def linkage_data(&block)
-      if block.nil?
-        @_linkage_data ||=
-          if @_linkage_data_block
-            @_linkage_data_block.call
-          elsif data.respond_to?(:each)
-            data.map { |res| { type: res.type, id: res.id } }
-          elsif data.nil?
-            nil
-          else
-            { type: data.type, id: data.id }
-          end
-      else
-        @_linkage_data_block = block
-      end
-    end
+    def as_jsonapi(included)
+      hash = {}
+      hash[:links] = @_links if @_links.any?
+      hash[:meta] = @_meta unless @_meta.nil?
+      hash[:data] = eval_linkage_data if included
 
-    def meta(value = nil, &block)
-      if value.nil? && block.nil?
-        @_meta
-      else
-        @_meta = (value || block.call)
-      end
-    end
-
-    def links
-      @_links
+      hash
     end
 
     private
 
+    def eval_linkage_data
+      @_linkage_data ||=
+        if @_linkage_data_block
+          @_linkage_data_block.call
+        elsif data.respond_to?(:each)
+          data.map { |res| { type: res.jsonapi_type, id: res.jsonapi_id } }
+        elsif data.nil?
+          nil
+        else
+          { type: data.jsonapi_type, id: data.jsonapi_id }
+        end
+    end
+
+    def linkage_data(&block)
+      @_linkage_data_block = block
+    end
+
+    def meta(value = nil, &block)
+      @_meta = value || block.call
+    end
+
     def link(name, &block)
-      @_links[name] = JSONAPI::SerializableLink.new(@_param_hash, &block).to_hash
+      @_links[name] = JSONAPI::SerializableLink.as_jsonapi(@_param_hash, &block)
     end
   end
 end

--- a/lib/jsonapi/serializable_relationship.rb
+++ b/lib/jsonapi/serializable_relationship.rb
@@ -45,8 +45,8 @@ module JSONAPI
       @_linkage_data_block = block
     end
 
-    def meta(value = nil, &block)
-      @_meta = value || block.call
+    def meta(value = nil)
+      @_meta = value || yield
     end
 
     def link(name, &block)

--- a/lib/jsonapi/serializable_relationship.rb
+++ b/lib/jsonapi/serializable_relationship.rb
@@ -21,7 +21,16 @@ module JSONAPI
 
     def linkage_data(&block)
       if block.nil?
-        @_linkage_data ||= (@_linkage_data_block && @_linkage_data_block.call)
+        @_linkage_data ||=
+          if @_linkage_data_block
+            @_linkage_data_block.call
+          elsif data.respond_to?(:each)
+            data.map { |res| { type: res.type, id: res.id } }
+          elsif data.nil?
+            nil
+          else
+            { type: data.type, id: data.id }
+          end
       else
         @_linkage_data_block = block
       end

--- a/lib/jsonapi/serializable_resource.rb
+++ b/lib/jsonapi/serializable_resource.rb
@@ -1,0 +1,102 @@
+require 'jsonapi/serializable_link'
+require 'jsonapi/serializable_relationship'
+
+# TEMP
+require 'active_support/core_ext/class/attribute'
+
+module JSONAPI
+  class SerializableResource
+    class_attribute :type
+    class_attribute :type_block
+    class_attribute :id_block
+    class_attribute :attribute_blocks
+    class_attribute :relationship_blocks
+    class_attribute :link_blocks
+    class_attribute :meta
+    class_attribute :meta_block
+
+    def self.inherited(subclass)
+      subclass.attribute_blocks = {}
+      subclass.relationship_blocks = {}
+      subclass.link_blocks = {}
+    end
+    
+    def self.type(value = nil, &block)
+      self.type = value
+      self.type_block = block
+    end
+
+    def self.id(&block)
+      self.id_block = block
+    end
+
+    def self.attribute(name, &block)
+      self.attribute_blocks[name] = block
+    end
+
+    def self.relationship(name, &block)
+      self.relationship_blocks[name] = block
+    end
+    
+    def self.link(name, &block)
+      self.link_blocks[name] = block
+    end
+
+    def self.meta(value = nil, &block)
+      self.meta = value
+      self.meta_block = block
+    end
+
+    def initialize(params = {})
+      @_param_hash = params
+      params.each do |name, value|
+        instance_variable_set("@#{name}", value)
+      end
+    end
+
+    def id
+      @_id ||= instance_eval(&self.class.id_block)
+    end
+
+    def type
+      @_type ||= (self.class.type || instance_eval(&self.class.type_block))
+    end
+
+    def attributes
+      @_attributes ||=
+        Hash[self.class.attribute_blocks.map { |k, v| [k, eval_attribute(v)] }]
+    end
+
+    def relationships
+      @_relationships ||=
+        Hash[self.class.relationship_blocks.map { |k, v| [k, eval_relationship(v)] }]
+    end
+
+    def links
+      @_links ||= Hash[self.class.link_blocks.map { |k, v| [k, eval_link(v)] }]
+    end
+
+    def meta
+      @_meta ||=
+        if self.class.meta
+          self.class.meta
+        elsif self.class.meta_block
+          instance_eval(&self.class.meta_block)
+        end
+    end
+
+    private
+
+    def eval_attribute(block)
+      instance_eval(&block)
+    end
+
+    def eval_relationship(block)
+      JSONAPI::SerializableRelationship.new(@_param_hash, &block)
+    end
+
+    def eval_link(block)
+      JSONAPI::SerializableLink.new(@_param_hash, &block).to_hash
+    end
+  end
+end

--- a/lib/jsonapi/serializable_resource.rb
+++ b/lib/jsonapi/serializable_resource.rb
@@ -31,15 +31,15 @@ module JSONAPI
     end
 
     def self.attribute(name, &block)
-      self.attribute_blocks[name] = block
+      attribute_blocks[name] = block
     end
 
     def self.relationship(name, &block)
-      self.relationship_blocks[name] = block
+      relationship_blocks[name] = block
     end
-    
+
     def self.link(name, &block)
-      self.link_blocks[name] = block
+      link_blocks[name] = block
     end
 
     def initialize(param_hash = {})
@@ -95,8 +95,8 @@ module JSONAPI
 
     def attributes(fields)
       self.class.attribute_blocks
-        .select { |k, v| !@_attributes.key?(k) && fields.include?(k) }
-        .each { |k, v| @_attributes[k] = instance_eval(&v) }
+          .select { |k, _| !@_attributes.key?(k) && fields.include?(k) }
+          .each { |k, v| @_attributes[k] = instance_eval(&v) }
       @_attributes.select { |k, _| fields.include?(k) }
     end
 


### PR DESCRIPTION
TODO: Description
Main idea: resources are separate entities, built from zero, one, or more server-level models, as well as possibly some other objects. They are responsible for serializing themselves, and listing their related resources depending on the requested ones. They are also responsible for stating their `id` and `type`. Although this whole process seems cumbersome, resource classes can be built from an helper DSL that makes it painless.

General-purpose renderer for resources. A resource is any object implementing the following interface:
```ruby
# @return [String]
def jsonapi_type; end

# @return [String]
def jsonapi_id; end

# @param [Hash] params
#   @option [Array<String>] fields List of whitelisted fields for this resource.
#   @option [Array<String>] include List of relationships to be included for this resource.
# @return [Hash] JSONAPI-compliant representation of the resource.
def as_jsonapi(params = {}); end

# @param [Array<String>] include List of relationships to be included for this resource.
# @return [Hash{Symbol => Resources}] List of resources to be included from this one.
def jsonapi_related(include); end
```

A resource could (but should not) directly be a model. It is a representation of the API-level entity that a resource is.

Moreover, this PR features a helper class `JSONAPI::SerializableResource`, which can be subclassed in order to define resources with a neat API (see example below). In the making is a subclass of `JSONAPI::SerializableResource` for ActiveRecord-backed models.

```ruby
# PORO User class
class User
  attr_accessor :id, :name, :address, :posts, :father
  def initialize(params)
    params.each do |k, v|
      instance_variable_set("@#{k}", v)
    end
  end
end
```
```ruby
# Some hypothetical UrlHelper class
class UrlHelper; end
```
```ruby
# Definition of UserResource through the API
class UserResource < JSONAPI::SerializableResource
  type 'users'

  id do
    @user.id.to_s
  end

  attribute :name do
    @user.name
  end

  attribute :address do
    @user.address
  end

  relationship :posts do
    link(:self) { @url_helper.link_for_rel('users', @user.id, 'posts') }
    meta do
      { count: @user.posts.count }
    end
    data do
      @user.posts.map do |p|
        PostResource.new(post: p, url_helper: @url_helper)
      end
    end
  end

  relationship :father do
    link(:self) do
      href @url_helper.link_for_rel('users', @user.id, 'father')
    end

    link(:related) do
      href @url_helper.link_for_res('users', 'relationships/father/value')
      meta "test"
    end

    meta do
      { certainty: "100%" }
    end

    data do
      if @user.father.nil?
        nil
      else
        UserResource.new(user: @user.father, url_helper: @url_helper)
      end
    end
  end

  link :self do
    @url_helper.link_for_res('users', @user.id)
  end

  meta do
    {
      trustable: (@user.name == "Lucas")
    }
  end
end
```
```ruby
# Render call
JSONAPI.render(UserResource.new(user: @users[1], url_helper: UrlHelper),
                      include: 'posts,father', fields: { user: ['name']})
```
```ruby
# Possible AR-specific API:
class RailsUserResource < JSONAPI::RailsSerializableResource
  model User

  attribute :name

  attribute :address

  has_many :posts, ::RailsPostResource do
    meta do
      { count: @user.posts.count }
    end
  end

  has_one :father, ::RailsUserResource do
    meta do
      { certainty: "100%" }
    end
  end

  link :self do
    UrlHelper.link_for_res('users', @user.id)
  end

  meta do
    {
      trustable: (@user.name == "Lucas")
    }
  end
end
```
```ruby
# Possible implementation for an AR-specific interface:
    class SerializableResource < JSONAPI::RailsSerializableResource
      class << self
        attr_accessor :model_klass
      end

      def self.model(klass)
        self.model_klass = klass
        type klass.name.to_s
      end

      def self.attribute(name, &block)
        if block.nil?
          self.attribute_blocks[name] = Proc.new { @model.send(name) }
        else
          super(name, &block)
        end
      end

      def self.has_many(name, resource_klass = nil, &block)
        rails_block = Proc.new do
          data do
            # TODO(beauby): Add some configurated pagination.                                                                                                                     
            @model.send(name).map do |res|
              resource_klass.new(model: res)
            end
          end

          # TODO(beauby): Add some default links.                                                                                                                                 

          instance_eval(&block) unless block.nil?
        end

        relationship(name) { rails_block.call }
      end

      def self.has_one(name, resource_klass = nil, &block)
        rails_block = Proc.new do
          reflection = @@model_klass.reflections[name.to_sym]
          if reflection.belong_to? && resource_klass.type
            linkage_data do
              id = @model.send("#{name}_id")
              if id.nil?
                nil
              else
                { type: resource_klass.type, id: id }
              end
            end
          end

          data do
            res = @model.send(name)
            if res.nil?
              nil
            else
              resource_klass.new(model: res)
            end
          end

          # TODO(beauby): Add some default links.                                                                                                                                 

          instance_eval(&block) unless block.nil?
        end

        relationship(name) { rails_block.call }
      end

      id do
        @model.id
      end
    end
```