### PR TITLE
Remove json dependency. `JSONAPI.parse` now requires a hash.

### DIFF
--- a/parser/README.md
+++ b/parser/README.md
@@ -24,6 +24,7 @@ require 'jsonapi/parser'
 
 Then, parse a JSON API document:
 ```ruby
+json_hash = JSON.parse(json_string)
 document = JSONAPI.parse(json_hash)
 ```
 

--- a/parser/jsonapi-parser.gemspec
+++ b/parser/jsonapi-parser.gemspec
@@ -12,6 +12,4 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['LICENSE', 'README.md', 'lib/**/*']
   spec.require_path  = 'lib'
-
-  spec.add_dependency 'json', '~>1.8'
 end

--- a/parser/lib/jsonapi/parser.rb
+++ b/parser/lib/jsonapi/parser.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 require 'jsonapi/parser/attributes'
 require 'jsonapi/parser/document'
 require 'jsonapi/parser/error'
@@ -17,14 +15,12 @@ module JSONAPI
 
   # Parse a JSON API document.
   #
-  # @param document [Hash, String] the JSON API document.
-  # @param options [Hash] options
+  # @param [Hash] document The JSON API document.
+  # @param [Hash] options options
   #   @option options [Boolean] :id_optional (false) Whether the resource
   #     objects in the primary data must have an id.
   # @return [JSONAPI::Parser::Document]
   def parse(document, options = {})
-    hash = document.is_a?(Hash) ? document : JSON.parse(document)
-
-    Parser::Document.new(hash, options)
+    Parser::Document.new(document, options)
   end
 end

--- a/parser/lib/jsonapi/parser/document.rb
+++ b/parser/lib/jsonapi/parser/document.rb
@@ -5,6 +5,7 @@ module JSONAPI
       attr_reader :data, :meta, :errors, :json_api, :links, :included
 
       def initialize(document_hash, options = {})
+        fail InvalidDocument if document_hash.nil?
         @hash = document_hash
         @options = options
         @data_defined = document_hash.key?('data')


### PR DESCRIPTION
Fixes #35, superseds #33, #37.