### PR TITLE
[parser] Avoid crashing when encountering non-hash values for relationships.

### DIFF
--- a/parser/lib/jsonapi/parser/relationships.rb
+++ b/parser/lib/jsonapi/parser/relationships.rb
@@ -12,6 +12,11 @@ module JSONAPI
         @hash = relationships_hash
         @relationships = {}
         relationships_hash.each do |rel_name, rel_hash|
+          unless rel_hash.is_a?(Hash)
+            fail InvalidDocument,
+                 "the value of a relationship MUST be an object"
+          end
+
           @relationships[rel_name.to_s] = Relationship.new(rel_hash, options)
           define_singleton_method(rel_name) do
             @relationships[rel_name.to_s]

--- a/parser/spec/parser_spec.rb
+++ b/parser/spec/parser_spec.rb
@@ -94,4 +94,20 @@ describe JSONAPI::Parser, '#parse' do
     expect(document.data.first.relationships.author.data.to_hash).to eq @author_data_hash
     expect(document.data.first.relationships.comments.data.map(&:to_hash)).to eq @comments_data_hash
   end
+
+  context 'when a relationship has nil value' do
+    it 'raises InvalidDocument' do
+      payload = {
+        'data' => {
+          'type' => 'users',
+          'relationships' => {
+            'posts' => nil
+          }
+        }
+      }
+
+      expect { JSONAPI.parse(payload) }
+        .to raise_error JSONAPI::Parser::InvalidDocument
+    end
+  end
 end


### PR DESCRIPTION
Example failing payload:
```ruby
{
  'data' => {
    'id' => '1',
    'type' => 'users',
    'relationships' => {
      'posts' => nil # instead of 'posts' => { 'data' => [] }
    }
  }
} 
```