### PR TITLE
Renderer: Handle nil related resources.

### DIFF
--- a/renderer/lib/jsonapi/renderer.rb
+++ b/renderer/lib/jsonapi/renderer.rb
@@ -74,6 +74,7 @@ module JSONAPI
     def process_relationships(res, prefix, include_dir)
       res.jsonapi_related(include_dir.keys).each do |key, data|
         Array(data).each do |child_res|
+          next if child_res.nil?
           child_prefix = "#{prefix}.#{key}"
           next unless @processed.add?([child_res.jsonapi_type,
                                        child_res.jsonapi_id,


### PR DESCRIPTION
Related resources that respond (positively) to `#nil?` will be discarded during included relationship serialization.